### PR TITLE
rm Alexandria dependency

### DIFF
--- a/cl-change-case.asd
+++ b/cl-change-case.asd
@@ -9,8 +9,7 @@
   :license "LLGPL"
   :source-control (:git "git@github.com:rudolfochrist/cl-change-case.git")
   :bug-tracker "https://github.com/rudolfochrist/cl-change-case/issues"
-  :depends-on (:alexandria
-               :cl-ppcre
+  :depends-on (:cl-ppcre
                :cl-ppcre-unicode)
   :components ((:module "src"
                 :components ((:file "cl-change-case"))))

--- a/src/cl-change-case.lisp
+++ b/src/cl-change-case.lisp
@@ -4,8 +4,6 @@
 (defpackage #:cl-change-case
   (:nicknames :change-case)
   (:use :cl)
-  (:import-from :alexandria
-                #:define-constant)
   (:import-from :cl-ppcre
                 #:regex-replace-all)
   (:export
@@ -30,7 +28,7 @@
 
 (in-package :cl-change-case)
 
-(define-constant +empty-string+ "" :test #'string=)
+(defvar +empty-string+ "")
 
 
 ;;; lower case


### PR DESCRIPTION
Hello,

I see that Alexandria is nearly not used, so I suggest to remove it. Pulling it all is not as lightweight as I'd like, it does create a significantly heavier binary.

Regards