### PR TITLE
Add the version file as a component

### DIFF
--- a/cl-change-case.asd
+++ b/cl-change-case.asd
@@ -10,7 +10,8 @@
   :depends-on ("cl-ppcre"
                "cl-ppcre-unicode")
   :components ((:module "src"
-                :components ((:file "cl-change-case"))))
+                :components ((:file "cl-change-case")))
+               (:static-file "version"))
   :description "Convert strings between camelCase, param-case, PascalCase and more"
   :in-order-to ((test-op (load-op cl-change-case/test))))
 


### PR DESCRIPTION
I was trying to load this library into a jar via asdf-jar which
removes any files like licenses and documentation. This would normally
be okay, but cl-change-case read the "version" file as part of loading
the .asd file (required to load cl-change-case). Thus it should be a
required component.